### PR TITLE
checks for labels in forms

### DIFF
--- a/app/templates/url-input.html
+++ b/app/templates/url-input.html
@@ -11,6 +11,7 @@
     <li>Link labels: We note if a link label matches an example poor link text from our <a href="https://github.com/tad-web/waqc/blob/master/config/bad_link_labels.txt">list of bad link labels</a>.</li>
     <li>Image alt text: We note if an image has no alt text or if the alt text contains a file extension.</li>
     <li>Header hierarchy: We note if the first header on a page is not an h1 or if header levels are skipped.</li>
+    <li>Form labels: We note if an editable form in a field is unlabeled.</li>
   </ul>
   <center>
     <form method="POST" action="/subpage-selection">

--- a/config/edit_field_types.txt
+++ b/config/edit_field_types.txt
@@ -1,0 +1,13 @@
+date
+datetime-local
+email
+text
+month
+number
+password
+search
+tel
+time
+url
+week
+no type

--- a/src/enums.py
+++ b/src/enums.py
@@ -14,6 +14,7 @@ class Flavor(Enum):
   ALT_TEXT = 2
   COLOR_CONTRAST = 3
   HEADER = 4
+  FORM_LABEL = 5
 
   def __str__(self):
     return ' '.join([word.title() for word in self.name.split('_')])

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,11 @@ from html_parser import HTMLParser
 
 
 if __name__ == '__main__':
-  url = 'https://www.carroll.org/'
+  url = 'http://www.tumblr.com'
   html_parser = HTMLParser([url])
-  navbar_links = html_parser.get_navbar_links(url)
-  for link in navbar_links:
-    print(link)
+  form_tags = html_parser.get_form_tags(url)
+  form_notices = html_parser.get_bad_form_label_notices(url)
+  print(form_notices)
+  for form in form_notices:
+      print(form)
+  # [print(form.prettify(), "\n") for form in form_tags]


### PR DESCRIPTION
I'm not sure this checks for all the ways forms can be labeled. Let me know if you find something legit that gets marked as a violation!

My message is set up the way it is because sometimes sites will have invisible forms where their invisibility is only indicated in css, so my thing false positives on those. Not sure if they would be read from a screenreader though?